### PR TITLE
Add Disk Cache for requests.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "qalam",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/guardian/qalam.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "99d955af8a43c8ae3fd0c1c71ba2af099a49f2f6"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Sources/Nophan/Managers/RequestCache.swift
+++ b/Sources/Nophan/Managers/RequestCache.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  RequestCache.swift
 //
 //
 //  Created by Usman Nazir on 28/05/2024.
@@ -82,6 +82,9 @@ extension RequestCache {
         do {
             let data = try Data(contentsOf: fileURL)
             failedTasksQueue = try decoder.decode([NophanRequest].self, from: data)
+        } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
+            Log.console("No Failed Requests cache found on disk: \(error.localizedDescription)\nInitializing empty Failed Tasks Queue.", .error, .nophan)
+            failedTasksQueue = []
         } catch {
             Log.console("Failed to load failed requests from disk: \(error.localizedDescription)", .error, .nophan)
         }

--- a/Sources/Nophan/Managers/RequestCache.swift
+++ b/Sources/Nophan/Managers/RequestCache.swift
@@ -1,0 +1,89 @@
+//
+//  File.swift
+//
+//
+//  Created by Usman Nazir on 28/05/2024.
+//
+
+import Foundation
+import Qalam
+
+/// A cache for managing failed network requests, storing them to disk and allowing retrieval for retry purposes.
+internal class RequestCache: Cache {
+    /// An array to store the queue of failed requests.
+    private var failedTasksQueue = [NophanRequest]()
+    
+    /// The file URL where the failed requests queue is stored.
+    private let fileURL: URL = getDocumentsDirectory()
+    
+    /// A dispatch queue for synchronizing access to the queue.
+    private let queue = DispatchQueue(label: "com.nophan.requestCacheQueue")
+    
+    /// A boolean property indicating if the failed requests queue is empty.
+    var isEmpty: Bool {
+        queue.sync {
+            failedTasksQueue.isEmpty
+        }
+    }
+    
+    /// Initializes a new instance of `RequestCache` and loads the queue from disk.
+    init() {
+        self.loadQueue()
+    }
+    
+    /// Adds a failed request to the queue and saves the updated queue to disk.
+    ///
+    /// - Parameter request: The `NophanRequest` to add to the queue.
+    func addRequestToQueue(_ request: NophanRequest) {
+        queue.async(flags: .barrier) {
+            self.failedTasksQueue.append(request)
+            self.saveQueue()
+        }
+    }
+    
+    /// Retrieves and clears all failed requests from the queue.
+    ///
+    /// - Returns: An array of `NophanRequest` objects representing the failed requests.
+    func getFailedRequests() -> [NophanRequest] {
+        queue.sync {
+            let failedRequests = failedTasksQueue
+            failedTasksQueue = []
+            saveQueue()
+            return failedRequests
+        }
+    }
+}
+
+// MARK: - Disk utility functions
+extension RequestCache {
+    
+    /// Returns the URL for the application's support directory where the failed requests queue is stored.
+    ///
+    /// - Returns: A `URL` pointing to the `nophan_failed_queue.json` file.
+    private static func getDocumentsDirectory() -> URL {
+        let path = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0].appendingPathComponent("nophan_failed_queue.json")
+        return path
+    }
+    
+    /// Saves the failed requests queue to disk as a JSON file.
+    private func saveQueue() {
+        let encoder = JSONEncoder()
+        do {
+            let data = try encoder.encode(failedTasksQueue)
+            try data.write(to: fileURL)
+        } catch {
+            Log.console("Failed to sync failed requests to disk: \(error.localizedDescription)", .error, .nophan)
+        }
+    }
+    
+    /// Loads the failed requests queue from the JSON file on disk.
+    private func loadQueue() {
+        let decoder = JSONDecoder()
+        do {
+            let data = try Data(contentsOf: fileURL)
+            failedTasksQueue = try decoder.decode([NophanRequest].self, from: data)
+        } catch {
+            Log.console("Failed to load failed requests from disk: \(error.localizedDescription)", .error, .nophan)
+        }
+    }
+}

--- a/Sources/Nophan/Managers/RequestCache.swift
+++ b/Sources/Nophan/Managers/RequestCache.swift
@@ -83,7 +83,7 @@ extension RequestCache {
             let data = try Data(contentsOf: fileURL)
             failedTasksQueue = try decoder.decode([NophanRequest].self, from: data)
         } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
-            Log.console("No Failed Requests cache found on disk: \(error.localizedDescription)\nInitializing empty Failed Tasks Queue.", .error, .nophan)
+            Log.console("No Failed Requests cache found on disk: \(error.localizedDescription)\nInitializing empty Failed Tasks Queue.", .warning, .nophan)
             failedTasksQueue = []
         } catch {
             Log.console("Failed to load failed requests from disk: \(error.localizedDescription)", .error, .nophan)

--- a/Sources/Nophan/Protocols/Cache.swift
+++ b/Sources/Nophan/Protocols/Cache.swift
@@ -1,0 +1,25 @@
+//
+//  File.swift
+//  
+//
+//  Created by Usman Nazir on 28/05/2024.
+//
+
+import Foundation
+
+/// A protocol that defines the interface for a cache that stores and manages failed network requests.
+protocol Cache {
+    
+    /// A boolean property indicating if the cache is empty.
+    var isEmpty: Bool { get }
+    
+    /// Adds a failed request to the cache.
+    ///
+    /// - Parameter request: The `NophanRequest` to add to the cache.
+    func addRequestToQueue(_ request: NophanRequest)
+    
+    /// Retrieves and clears all failed requests from the cache.
+    ///
+    /// - Returns: An array of `NophanRequest` objects representing the failed requests.
+    func getFailedRequests() -> [NophanRequest]
+}

--- a/Sources/Nophan/Protocols/Cache.swift
+++ b/Sources/Nophan/Protocols/Cache.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  Cache.swift
+//
 //
 //  Created by Usman Nazir on 28/05/2024.
 //

--- a/Sources/Nophan/Protocols/Networking.swift
+++ b/Sources/Nophan/Protocols/Networking.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol Networking {
-    var failedTasksQueue: [NophanRequest] { get }
+    var requestCache: Cache { get }
     func request(request: NophanRequest) async throws
     func retryFailedRequests()
 }

--- a/Sources/Nophan/Structs/Request.swift
+++ b/Sources/Nophan/Structs/Request.swift
@@ -7,10 +7,33 @@
 
 import Foundation
 
-internal struct NophanRequest {
+internal struct NophanRequest: Codable {
     var endpointUrl: URL
     var parameters: [String : Any]
     var httpMethod: String {
         return "POST"
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case endpointUrl, parameters, httpMethod
+    }
+    
+    init(endpointUrl: URL, parameters: [String: Any]) {
+        self.endpointUrl = endpointUrl
+        self.parameters = parameters
+    }
+    
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        endpointUrl = try values.decode(URL.self, forKey: .endpointUrl)
+        let data = try values.decode(Data.self, forKey: .parameters)
+        parameters = try JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(endpointUrl, forKey: .endpointUrl)
+        let data = try JSONSerialization.data(withJSONObject: parameters, options: [])
+        try container.encode(data, forKey: .parameters)
     }
 }

--- a/Tests/NophanTests/MockManagers/MockCache.swift
+++ b/Tests/NophanTests/MockManagers/MockCache.swift
@@ -1,0 +1,25 @@
+//
+//  File.swift
+//
+//
+//  Created by Usman Nazir on 28/05/2024.
+//
+
+import Foundation
+@testable import Nophan
+
+class MockCache: Cache {
+    
+    private var failedTasksQueue = [NophanRequest]()
+    var isEmpty: Bool { failedTasksQueue.isEmpty }
+    
+    func addRequestToQueue(_ request: NophanRequest) {
+        failedTasksQueue.append(request)
+    }
+    
+    func getFailedRequests() -> [NophanRequest] {
+        let failedRequests = failedTasksQueue
+        failedTasksQueue = []
+        return failedRequests
+    }
+}

--- a/Tests/NophanTests/MockManagers/MockCache.swift
+++ b/Tests/NophanTests/MockManagers/MockCache.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  MockCache.swift
 //
 //
 //  Created by Usman Nazir on 28/05/2024.

--- a/Tests/NophanTests/NetworkEngineTests.swift
+++ b/Tests/NophanTests/NetworkEngineTests.swift
@@ -36,13 +36,19 @@ final class NetworkEngineTests: XCTestCase {
         // Wait before retry
         try? await Task.sleep(nanoseconds: 1 * 1_000_000_000) // 1 second
         
-        XCTAssertEqual(networkEngine.failedTasksQueue.last?.parameters["device_timestamp"] as? TimeInterval, deviceTimestamp,
+        var requests = networkEngine.requestCache.getFailedRequests()
+        
+        XCTAssertEqual(requests.last?.parameters["device_timestamp"] as? TimeInterval, deviceTimestamp,
                        "The Device Time-stamp should remain same event if the attempt is resumed after some time.")
+        
+        for failedRequest in requests { networkEngine.requestCache.addRequestToQueue(failedRequest) }
         
         networkEngine.shouldFail = false
         networkEngine.retryFailedRequests()
         
-        XCTAssertEqual(networkEngine.failedTasksQueue.count, 0,
+        requests = networkEngine.requestCache.getFailedRequests()
+        
+        XCTAssertEqual(requests.count, 0,
                        "The number of failed requests is 0 once the network engine is running properly.")
     }
 }

--- a/Tests/NophanTests/NophanTests.swift
+++ b/Tests/NophanTests/NophanTests.swift
@@ -29,7 +29,8 @@ final class NophanTests: XCTestCase {
     func testTrackEventWithoutConfiguration() async {
         let event = TestEvent(name: "Test", parameters: ["event": "testEvent"])
         nophan.trackEvent(event)
-        XCTAssertEqual(networkEngine.failedTasksQueue.count, 0, "No new request has been added.")
+        let requests = networkEngine.requestCache.getFailedRequests()
+        XCTAssertEqual(requests.count, 0, "No new request has been added.")
     }
     
     func testSetUserIdentifier() async {
@@ -48,8 +49,9 @@ final class NophanTests: XCTestCase {
         nophan.setup(configuration: configuration)
         nophan.trackEvent(event)
         try? await Task.sleep(nanoseconds: 1 * 1_000_000_000)
-        XCTAssertEqual(networkEngine.failedTasksQueue.count, 1)
-        XCTAssertEqual(networkEngine.failedTasksQueue.last?.parameters["name"] as! String, "Test")
+        let requests = networkEngine.requestCache.getFailedRequests()
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests.last?.parameters["name"] as! String, "Test")
     }
     
     func testTrackConfiguration() async {
@@ -57,8 +59,9 @@ final class NophanTests: XCTestCase {
         nophan.setup(configuration: configuration)
         nophan.trackConfiguration()
         try? await Task.sleep(nanoseconds: 1 * 1_000_000_000)
-        XCTAssertEqual(networkEngine.failedTasksQueue.count, 1)
-        XCTAssertEqual(networkEngine.failedTasksQueue.last?.parameters["os"] as? String, configuration.operatingSystem)
+        let requests = networkEngine.requestCache.getFailedRequests()
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests.last?.parameters["os"] as? String, configuration.operatingSystem)
     }
     
     func testTrackUser() async {
@@ -67,7 +70,8 @@ final class NophanTests: XCTestCase {
         nophan.setup(configuration: configuration)
         nophan.setUserIdentifier(id: userId)
         try? await Task.sleep(nanoseconds: 1 * 1_000_000_000)
-        XCTAssertEqual(networkEngine.failedTasksQueue.count, 1)
-        XCTAssertEqual(networkEngine.failedTasksQueue.last?.parameters["user"] as? String, "user123")
+        let requests = networkEngine.requestCache.getFailedRequests()
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests.last?.parameters["user"] as? String, "user123")
     }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds disk caching to save failed tracking requests on device.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

This can be tested in the Feast app.
1 - Disconnect from internet
2 - Remove breakpoints
3 - Bookmark a few recipes
4 - Restart app and connect debugger
5 - Bookmark a recipe and see the Network Engine in Nophan attempts to retry failed requests from last session.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Failed requests will get retried even if a new app session is started.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Nothing in particular. Need to make sure the time-stamp on each retried request remains the same.
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
