### PR TITLE
Add consent to Nophan

### DIFF
--- a/Sources/Nophan/Enums/NophanTrackingType.swift
+++ b/Sources/Nophan/Enums/NophanTrackingType.swift
@@ -16,6 +16,7 @@ enum TrackingType: String {
     case Configuration
     case User
     case Event
+    case Consent
     
     /// Provides the string value associated with each `TrackingType` case for use in parameters.
     ///
@@ -34,6 +35,8 @@ enum TrackingType: String {
             return "user"
         case .Event:
             return "event"
+        case .Consent:
+            return "consent"
         }
     }
 }

--- a/Sources/Nophan/Nophan.swift
+++ b/Sources/Nophan/Nophan.swift
@@ -58,6 +58,15 @@ public final class Nophan: Analytics {
         trackConfiguration()
     }
     
+    /// Sets up the consent for the FPA system.
+    /// Call this function as soon as the consent is updated.
+    ///
+    /// - Parameter consent: The consent to be used.
+    ///
+    public func updateConsent(with consent: NophanConsent) {
+        trackConsent(consent: consent)
+    }
+    
     /// Sets the user identifier in the configuration.
     /// Call this function whenever the user registers/signs-in.
     ///
@@ -118,6 +127,20 @@ extension Nophan {
             }
         }
     }
+    
+    /// Tracks the event relating to consent.
+    /// This event is tracked on app cold starts and when consent is updated.
+    internal func trackConsent(consent: NophanConsent) {
+        Task.detached { [weak self] in
+            do {
+                guard let self, let configuration else { throw NophanError.ConfigurationError }
+                let trackingRequest = try prepareRequest(for: consent)
+                try await networkEngine.request(request: trackingRequest)
+            } catch {
+                Log.console("Failed to track Consent", .error, .nophan)
+            }
+        }
+    }
 }
 
 extension Nophan {
@@ -152,6 +175,17 @@ extension Nophan {
         guard let configuration else { throw NophanError.ConfigurationError }
         debuggingParameters(parameters: &parameters)
         trackingTypeParameters(type: .User, parameters: &parameters)
+        additionalParameters(parameters: &parameters)
+        return NophanRequest(endpointUrl: configuration.endpointUrl, parameters: parameters)
+    }
+    
+    // Prepare the request for a consent change.
+    internal func prepareRequest(for consent: NophanConsent) throws -> NophanRequest {
+        var parameters: [String: Any] = consent.parameters
+        guard let configuration else { throw NophanError.ConfigurationError }
+        userParameters(parameters: &parameters)
+        debuggingParameters(parameters: &parameters)
+        trackingTypeParameters(type: .Consent, parameters: &parameters)
         additionalParameters(parameters: &parameters)
         return NophanRequest(endpointUrl: configuration.endpointUrl, parameters: parameters)
     }

--- a/Sources/Nophan/Protocols/Consent.swift
+++ b/Sources/Nophan/Protocols/Consent.swift
@@ -13,6 +13,13 @@ public struct NophanConsent {
     let consentUUID: String
     let cmpVersion: String
     
+    public init(jurisdiction: String, consent: String, consentUUID: String, cmpVersion: String) {
+        self.jurisdiction = jurisdiction
+        self.consent = consent
+        self.consentUUID = consentUUID
+        self.cmpVersion = cmpVersion
+    }
+    
     var parameters: [String:String] {
         return [
             "jurisdiction": jurisdiction,

--- a/Sources/Nophan/Protocols/Consent.swift
+++ b/Sources/Nophan/Protocols/Consent.swift
@@ -1,0 +1,24 @@
+//
+//  Consent.swift
+//
+//
+//  Created by Usman Nazir on 29/05/2024.
+//
+
+import Foundation
+
+public struct NophanConsent {
+    let jurisdiction: String
+    let consent: String
+    let consentUUID: String
+    let cmpVersion: String
+    
+    var parameters: [String:String] {
+        return [
+            "jurisdiction": jurisdiction,
+            "consent": consent,
+            "consentUUID": consentUUID,
+            "cmpVersion": cmpVersion
+        ]
+    }
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds consent tracking ability to Nophan.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

This will just be a code review. This will be tested in a separate PR on Feast repo.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
