### PR TITLE
Update NophanMonitor.swift to be thread safe.

### DIFF
--- a/Sources/Nophan/Debug/NophanMonitor.swift
+++ b/Sources/Nophan/Debug/NophanMonitor.swift
@@ -16,11 +16,16 @@ internal class NophanMonitor: ObservableObject {
     /// An array to store the last 15 NophanRequest objects.
     @Published private(set) var events: [NophanRequest] = []
 
+    /// Dispatch queue to modify events in a Thread Safe manner.
+    let queue = DispatchQueue(label: "NophanMonitorEventsQueue")
+    
     /// Adds a new event to the array, ensuring only the last 15 events are kept.
     func addEvent(_ event: NophanRequest) {
-        if events.count >= 15 {
-            events.removeFirst()
+        queue.async(flags: .barrier) {
+            if self.events.count >= 15 {
+                self.events.removeFirst()
+            }
+            self.events.append(event)
         }
-        events.append(event)
     }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
