### PR TITLE
Add core4 workflow

### DIFF
--- a/.github/workflows/check-labels.yaml
+++ b/.github/workflows/check-labels.yaml
@@ -1,0 +1,9 @@
+name: CORE4 label enforcement
+permissions:
+  contents: read
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened, edited]
+jobs:
+  require-label:
+    uses: guardian/.github/.github/workflows/require-label.yaml@4cb5024736632ffcc564b7f4b772c38b8e5ce739 #  v2.0.0


### PR DESCRIPTION
This PR adds a workflow that enforces one of the CORE4 labels on PRs prior to merge. This PR is already lablled with the maintenance label to allow the workflow to pass.